### PR TITLE
Revert parts of ascii_to_model.py to better support RCRA

### DIFF
--- a/ascii_to_model.py
+++ b/ascii_to_model.py
@@ -276,22 +276,43 @@ class ModelInjector(object):
 		return result
 
 	def update_lookgroups(self, ascii_data, lookgroups_overrides):
+		looks = [0]
+		lod = 0
+
+		#
+
 		looks_section = self.model.dat1.get_section(SECTION_LOOK)
-		looks_count = len(looks_section.looks)
 
-		meshes_count = len(ascii_data["meshes"])
-		overrides = [(0, meshes_count)]
-		if looks_count > 1:
-			overrides += [(0, meshes_count)]
+		s = self.model.dat1.get_section(SECTION_MESHES)
+		meshes = s.meshes
 
-		if "lookgroups" in lookgroups_overrides:
-			overrides = lookgroups_overrides["lookgroups"]
+		meshes_to_display = set()
+		for look in looks:
+			look_lod = looks_section.looks[look].lods[lod]
+			meshes_to_display |= set(range(look_lod.start, look_lod.start + look_lod.count))
 
-		for i in range(len(overrides)):
-			look = looks_section.looks[i]
-			for j in range(6):
-				look.lods[j].start = overrides[i][0]
-				look.lods[j].count = overrides[i][1]
+		meshes_indexes = []
+		for i, mesh in enumerate(meshes):
+			if i not in meshes_to_display:
+				continue
+
+			meshes_indexes += [i]
+
+		#
+
+		for look in looks:
+			look_lod = looks_section.looks[look].lods[lod]
+			for lod_i in range(len(looks_section.looks[look].lods)):
+				if lod_i == lod:
+					continue
+
+				if looks_section.looks[look].lods[lod_i].start == 0 and looks_section.looks[look].lods[lod_i].count == 0:
+					continue
+				
+				looks_section.looks[look].lods[lod_i].start = look_lod.start
+				looks_section.looks[look].lods[lod_i].count = look_lod.count
+
+		#
 
 		self.refresh_section(SECTION_LOOK)
 
@@ -313,12 +334,15 @@ class ModelInjector(object):
 			mesh.indexStart = new_mesh[2]
 			mesh.indexCount = new_mesh[3]
 			
-			if (mesh.get_flags() & 0x10) > 0:
+			if (mesh.get_flags() & 0x10) > 0 or self.mode == dat1lib.VERSION_RCRA:
 				mesh.first_skin_batch = new_mesh[4]
 				mesh.skin_batches_count = new_mesh[6]
 
 			if (mesh.get_flags() & 0x100) > 0:
 				mesh.first_weight_index = new_mesh[5]
+                
+			if self.mode == dat1lib.VERSION_RCRA:
+                return
 
 			mesh.flags = mesh.get_flags() & 0x111
 
@@ -365,7 +389,7 @@ class ModelInjector(object):
 				if has_skin:
 					w = self.get_vertex_weights(groups_data, weights_data)
 					self.write_weight(w)
-					if has_rcra_skin:
+					if self.mode == dat1lib.VERSION_RCRA:
 						self.write_rcra_weight(w)
 						
 

--- a/ascii_to_model.py
+++ b/ascii_to_model.py
@@ -342,7 +342,7 @@ class ModelInjector(object):
 				mesh.first_weight_index = new_mesh[5]
                 
 			if self.mode == dat1lib.VERSION_RCRA:
-                return
+				return
 
 			mesh.flags = mesh.get_flags() & 0x111
 

--- a/ascii_to_model.py
+++ b/ascii_to_model.py
@@ -333,28 +333,24 @@ class ModelInjector(object):
 			mesh.vertexCount = new_mesh[1]
 			mesh.indexStart = new_mesh[2]
 			mesh.indexCount = new_mesh[3]
-			
-			if (mesh.get_flags() & 0x10) > 0 or self.mode == dat1lib.VERSION_RCRA:
-				mesh.first_skin_batch = new_mesh[4]
-				mesh.skin_batches_count = new_mesh[6]
+			mesh.first_skin_batch = new_mesh[4]
+			mesh.skin_batches_count = new_mesh[6]
 
 			if (mesh.get_flags() & 0x100) > 0:
 				mesh.first_weight_index = new_mesh[5]
-                
-			if self.mode == dat1lib.VERSION_RCRA:
-				return
 
 			mesh.flags = mesh.get_flags() & 0x111
 
-			if i < len(overrides):
+			if i < len(overrides) and self.mode != dat1lib.VERSION_RCRA:
 				mesh.material_index = overrides[i]
-			elif i < materials_count:
+			elif i < materials_count and self.mode != dat1lib.VERSION_RCRA:
 				mesh.material_index = i
-			else:
+			elif self.mode != dat1lib.VERSION_RCRA:
 				mesh.material_index = 0
 
 		for i in range(len(meshes_updates), len(meshes)):
-			meshes[i].clear()
+			if  self.mode != dat1lib.VERSION_RCRA:
+				meshes[i].clear()
 
 		self.refresh_section(SECTION_MESHES)
 


### PR DESCRIPTION
Fixed some breaking issues for model reimporting specific to RCRA. Sadly, a good chunk of the fixes involved reverting code to 0.3.1, the last release that worked for the game insofar as my tests. Also had to omit the mesh clearing method because otherwise the game would crash for me after enough elapsed time. Revisions for the sake of compatibility with other games are welcome.

<!--
    Thank you for contributing to ALERT.
    Please read the following carefully before creating submitting your Pull Request.

    If your code change is breaking, or doesn't fit the project, it could be rejected.

    --

    Briefly describe what does your PR change.

    If you introduce a new concept or change the existing logic dramatically,
    please describe the implementation details as well.

    Attach screenshots or pictures if it's applicable.

    Don't include this text (between < and >) in your PR description.
-->
